### PR TITLE
mandatory username fix

### DIFF
--- a/oarepo_oidc_einfra/services/components/aai_invitations.py
+++ b/oarepo_oidc_einfra/services/components/aai_invitations.py
@@ -282,7 +282,7 @@ class AAIInvitationComponent(ServiceComponent):
 
         user = current_users_service.create(
             system_identity,
-            {"email": member_email},
+            {"email": member_email, "username": None},
         )
 
         u = db.session.query(User).get(user["id"])


### PR DESCRIPTION
rdm-14 requires username to be sent to the service, though it can be empty.